### PR TITLE
feat: set initial coords from previous plan

### DIFF
--- a/apps/expo-app/app/(auth)/plans/new.tsx
+++ b/apps/expo-app/app/(auth)/plans/new.tsx
@@ -73,7 +73,7 @@ const CANCEL_TRIGGER_TIMES = 5;
 
 export default function PlansNew() {
   const router = useRouter();
-  const { planAdd } = useStorePlans();
+  const { planAdd, data: plans } = useStorePlans();
   const [startCoords, setStartCoords] = useUrlParams("start", coordsSchema);
   const [finishCoords, setFinishCoords] = useUrlParams("finish", coordsSchema);
   const [cancelPressedTimes, setCancelPressedTimes] = useState(0);
@@ -263,6 +263,11 @@ export default function PlansNew() {
 
   const [mapMode, setMapMode] = useUrlParams("map-mode", z.boolean());
 
+  const initialCoords = useMemo(() => {
+    const prevPlan = plans?.[0];
+    return prevPlan ? [prevPlan.startLat, prevPlan.startLon] : null;
+  }, [plans]);
+
   return (
     <ScreenFrame
       title="New plan"
@@ -381,7 +386,7 @@ export default function PlansNew() {
     >
       <View className="flex flex-col items-center justify-start">
         <AnimatePresence>
-          {mapMode && (
+          {mapMode && initialCoords && (
             <MotiView
               key="big-map"
               className="fixed top-0 z-50 mt-16 w-[98vw] bg-white p-4 pb-40 dark:bg-gray-900"
@@ -391,6 +396,7 @@ export default function PlansNew() {
               transition={{ type: "timing" }}
             >
               <GeoMapCoordsSelector
+                initialCoords={initialCoords}
                 onCoordsSelectCancel={() => {
                   setCancelPressedTimes((t) => t + 1);
                   if (cancelPressedTimes >= CANCEL_TRIGGER_TIMES) {
@@ -725,23 +731,26 @@ export default function PlansNew() {
             }}
           >
             <GroupWithTitle title="Overview" className="h-48">
-              <GeoMapPlanView
-                bearing={isRoundTrip ? (bearing ?? null) : null}
-                distance={(selectedDistance || 0) * 1000}
-                start={
-                  startCoords
-                    ? {
-                        lat: startCoords[0],
-                        lon: startCoords[1],
-                      }
-                    : null
-                }
-                finish={
-                  finishCoords
-                    ? { lat: finishCoords[0], lon: finishCoords[1] }
-                    : null
-                }
-              />
+              {!!initialCoords && (
+                <GeoMapPlanView
+                  bearing={isRoundTrip ? (bearing ?? null) : null}
+                  distance={(selectedDistance || 0) * 1000}
+                  initialCoords={initialCoords}
+                  start={
+                    startCoords
+                      ? {
+                          lat: startCoords[0],
+                          lon: startCoords[1],
+                        }
+                      : null
+                  }
+                  finish={
+                    finishCoords
+                      ? { lat: finishCoords[0], lon: finishCoords[1] }
+                      : null
+                  }
+                />
+              )}
             </GroupWithTitle>
           </Pressable>
           <AnimatePresence>

--- a/apps/expo-app/app/(auth)/plans/new.tsx
+++ b/apps/expo-app/app/(auth)/plans/new.tsx
@@ -73,7 +73,7 @@ const CANCEL_TRIGGER_TIMES = 5;
 
 export default function PlansNew() {
   const router = useRouter();
-  const { planAdd, data: plans } = useStorePlans();
+  const { planAdd, data: plans, loading: plansLoading } = useStorePlans();
   const [startCoords, setStartCoords] = useUrlParams("start", coordsSchema);
   const [finishCoords, setFinishCoords] = useUrlParams("finish", coordsSchema);
   const [cancelPressedTimes, setCancelPressedTimes] = useState(0);
@@ -265,8 +265,11 @@ export default function PlansNew() {
 
   const initialCoords = useMemo(() => {
     const prevPlan = plans?.[0];
+    if (!plansLoading && !prevPlan) {
+      return [57.153614, 24.85391];
+    }
     return prevPlan ? [prevPlan.startLat, prevPlan.startLon] : null;
-  }, [plans]);
+  }, [plans, plansLoading]);
 
   return (
     <ScreenFrame

--- a/apps/expo-app/components/geo-map/geo-map-coords-selector.tsx
+++ b/apps/expo-app/components/geo-map/geo-map-coords-selector.tsx
@@ -1,4 +1,7 @@
 import { getMapStyle } from "@ridi/geo-maps";
+
+import { useStorePlans } from "~/lib/stores/plans-store";
+
 import * as turf from "@turf/turf";
 import {
   type FillLayer,
@@ -63,6 +66,7 @@ export function GeoMapCoordsSelector({
   regions,
   children,
   onCoordsSelectCancel,
+  initialCoords,
 }: GeoMapCoordsSelectorProps) {
   const { colorScheme } = useColorScheme();
   const mapRef = useRef<MapRef>(null);
@@ -162,9 +166,9 @@ export function GeoMapCoordsSelector({
               bounds: mapBounds,
             }
           : {
-              longitude: 24.853,
-              latitude: 57.153,
-              zoom: 4,
+              longitude: initialCoords[1],
+              latitude: initialCoords[0],
+              zoom: 5,
             }
       }
       mapStyle={getMapStyle(colorScheme)}

--- a/apps/expo-app/components/geo-map/geo-map-coords-selector.tsx
+++ b/apps/expo-app/components/geo-map/geo-map-coords-selector.tsx
@@ -1,7 +1,5 @@
 import { getMapStyle } from "@ridi/geo-maps";
 
-import { useStorePlans } from "~/lib/stores/plans-store";
-
 import * as turf from "@turf/turf";
 import {
   type FillLayer,

--- a/apps/expo-app/components/geo-map/types.ts
+++ b/apps/expo-app/components/geo-map/types.ts
@@ -4,6 +4,7 @@ import { type Region } from "~/lib/regions";
 
 export type GeoMapCoordsSelectorProps = {
   isRoundTrip: boolean;
+  initialCoords: [number, number];
   start?: Coords | null;
   finish?: Coords | null;
   current?: Coords | null;

--- a/libs/geo-maps/src/geo-map/geo-map-plan-view.tsx
+++ b/libs/geo-maps/src/geo-map/geo-map-plan-view.tsx
@@ -64,8 +64,8 @@ export function GeoMapPlanView(props: GeoMapPlanViewProps) {
               bounds: updateBBox(bbox),
             }
           : {
-              longitude: 24.853,
-              latitude: 57.153,
+              longitude: props.initialCoords[1],
+              latitude: props.initialCoords[0],
               zoom: 4,
             }
       }

--- a/libs/geo-maps/src/geo-map/types.ts
+++ b/libs/geo-maps/src/geo-map/types.ts
@@ -2,6 +2,7 @@ import { type MapRef } from "@vis.gl/react-maplibre";
 import { type PropsWithChildren } from "react";
 
 export type GeoMapPlanViewProps = {
+  initialCoords: [number, number];
   start: Coords | null;
   finish: Coords | null;
   bearing: number | null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map views now use coordinates from existing plans to set their initial location, providing a more relevant starting point.
* **Improvements**
  * The map and plan view components only display when initial coordinates are available, ensuring accurate rendering.
  * The zoom level for the map view has been adjusted for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->